### PR TITLE
Wikipedia::revisions - specify `rvslots`

### DIFF
--- a/lib/bot.php
+++ b/lib/bot.php
@@ -145,7 +145,7 @@ function doarchive(
     ));
     unset($tmp);
 
-    $cursects = splitintosections($rv[0]['*'], $level);
+    $cursects = splitintosections($rv[0]['slots']['main']['*'], $level);
 
     $ans = array();
     $anr = array();
@@ -183,11 +183,11 @@ function doarchive(
         }
     }
     if ($lastrvid == null) {
-        $tmp = array(array('*' => ''));
+        $tmp = array(array('slots' => array('main' => array('*' => ''))));
     } else {
         $tmp = $wpapi->revisions($page, 1, 'older', true, $lastrvid);
     }
-    $oldsects = splitintosections($tmp[0]['*'], $level);
+    $oldsects = splitintosections($tmp[0]['slots']['main']['*'], $level);
     $header = $cursects[0];
     unset($cursects[0]);
     unset($oldsects[0]);

--- a/lib/wikipedia.api.php
+++ b/lib/wikipedia.api.php
@@ -330,7 +330,7 @@ class WikipediaApi
         $redirects = false
     ) {
         global $logger;
-        $url = $this->apiurl . '?action=query&rawcontinue=1&prop=revisions&titles=' .
+        $url = $this->apiurl . '?action=query&rawcontinue=1&prop=revisions&rvslots=main&titles=' .
                urlencode($page) . '&rvlimit=' . urlencode($count) . '&rvprop=timestamp|ids|user|comment' .
                (($content) ? '|content' : '') . '&format=php&meta=userinfo&rvdir=' . urlencode($dir) .
                (($revid !== null) ? '&rvstartid=' . urlencode($revid) : '') .

--- a/lib/wikipedia.index.php
+++ b/lib/wikipedia.index.php
@@ -77,8 +77,8 @@ class WikipediaIndex
         if ($rv == null) {
             $rv = $wpapi->revisions($page, 1, 'older', true);
         }
-        if (!$rv[0]['*']) {
-            $rv[0]['*'] = $wpq->getpage($page);
+        if (!$rv[0]['slots']['main']['*']) {
+            $rv[0]['slots']['main']['*'] = $wpq->getpage($page);
         }
 
         $now = gmdate('YmdHis', time());
@@ -97,18 +97,18 @@ class WikipediaIndex
         $html .= "<input type='hidden' value=\"{$token}\" name=\"wpEditToken\" />\n";
         $html .= '<input name="wpAutoSummary" type="hidden" value="' . md5('') . '" />' . "\n";
 
-        if (preg_match('/' . preg_quote('{{nobots}}', '/') . '/iS', $rv[0]['*'])) {
+        if (preg_match('/' . preg_quote('{{nobots}}', '/') . '/iS', $rv[0]['slots']['main']['*'])) {
             return false;
         }        /* Honor the bots flags */
-        if (preg_match('/' . preg_quote('{{bots|allow=none}}', '/') . '/iS', $rv[0]['*'])) {
+        if (preg_match('/' . preg_quote('{{bots|allow=none}}', '/') . '/iS', $rv[0]['slots']['main']['*'])) {
             return false;
         }
-        if (preg_match('/' . preg_quote('{{bots|deny=all}}', '/') . '/iS', $rv[0]['*'])) {
+        if (preg_match('/' . preg_quote('{{bots|deny=all}}', '/') . '/iS', $rv[0]['slots']['main']['*'])) {
             return false;
         }
         if (
             preg_match('/' . preg_quote('{{bots|deny=', '/') . '(.*)' .
-                                        preg_quote('}}', '/') . '/iS', $rv[0]['*'], $m)
+                                        preg_quote('}}', '/') . '/iS', $rv[0]['slots']['main']['*'], $m)
         ) {
             if (in_array(explode(',', $m[1]), $user)) {
                 return false;

--- a/lib/wikipedia.query.php
+++ b/lib/wikipedia.query.php
@@ -66,7 +66,7 @@ class WikipediaQuery
         $this->checkurl();
         $ret = $this->api->revisions($page, 1, 'older', true, null, true, false, false, false);
 
-        return $ret[0]['*'];
+        return $ret[0]['slots']['main']['*'];
     }
 
     /**


### PR DESCRIPTION
Per https://www.mediawiki.org/wiki/API:Revisions `rvslots` being omitted
will cause data to be returned in a backwards-compatible format, however
is deprecated.

Previously when `content` was requested the response would be structured
similar to
```
{
  "query": {
    "pages": {
      "xxx": {
        "revisions": [
          {
            "*": "Page content"
          }
        ]
      }
    }
  }
}
```

With the slot specified, the content is re-structured similar to
```
{
  "query": {
    "pages": {
      "xxx": {
        "revisions": [
          {
            "slots": {
              "main": {
                "*": "Page content"
              }
            }
          }
        ]
      }
    }
  }
}
```

Thus also update the consumers to look at the new structure.

Fixes #3